### PR TITLE
Added missing 'using'

### DIFF
--- a/IotaCSharpApi/Api/Utils/Rest/JsonWebClient.cs
+++ b/IotaCSharpApi/Api/Utils/Rest/JsonWebClient.cs
@@ -33,7 +33,7 @@ namespace Iota.Lib.CSharp.Api.Utils.Rest
 
             request.ContentLength = bytes.Length;
 
-            Stream requestStream = request.GetRequestStream();
+            using (Stream requestStream = request.GetRequestStream())
             {
                 // Send the data.
                 requestStream.Write(bytes, 0, bytes.Length);


### PR DESCRIPTION
In JsonWebClient the using for requestStream was missing. This could lead to the error "You must write ContentLength bytes to the request stream before calling [Begin]GetResponse."