### PR TITLE
Fixed exceptions for non-json responses

### DIFF
--- a/IotaCSharpApi/Api/Exception/IotaApiException.cs
+++ b/IotaCSharpApi/Api/Exception/IotaApiException.cs
@@ -13,5 +13,15 @@
         public IotaApiException(string error) : base(error)
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IotaApiException"/> class.
+        /// </summary>
+        /// <param name="message">The exception message.</param>
+        /// <param name="innerException">The inner exception.</param>
+        public IotaApiException(string message, System.Exception innerException)
+            : base(message, innerException)
+        {
+        }
     }
 }

--- a/IotaCSharpApi/Api/Utils/Rest/JsonWebClient.cs
+++ b/IotaCSharpApi/Api/Utils/Rest/JsonWebClient.cs
@@ -60,13 +60,23 @@ namespace Iota.Lib.CSharp.Api.Utils.Rest
             }
             catch (WebException ex)
             {
-                Console.WriteLine("catched: " + ex.ToString() + ex.Message);
+                Console.WriteLine("catched: " + ex);
 
                 using (var stream = ex.Response.GetResponseStream())
                 using (var reader = new StreamReader(stream))
                 {
-                    String errorResponse = reader.ReadToEnd();
-                    throw new IotaApiException(JsonConvert.DeserializeObject<ErrorResponse>(errorResponse).Error);
+                    var errorResponse = reader.ReadToEnd();
+                    string deserialized;
+                    try
+                    {
+                        deserialized = JsonConvert.DeserializeObject<ErrorResponse>(errorResponse).Error;
+                    }
+                    catch (System.Exception)
+                    {
+                        // errorResponse is not a valid JSON
+                        deserialized = errorResponse;
+                    }
+                    throw new IotaApiException(deserialized, ex);
                 }
             }
         }

--- a/IotaCSharpApi/Api/Utils/Rest/JsonWebClient.cs
+++ b/IotaCSharpApi/Api/Utils/Rest/JsonWebClient.cs
@@ -60,8 +60,6 @@ namespace Iota.Lib.CSharp.Api.Utils.Rest
             }
             catch (WebException ex)
             {
-                Console.WriteLine("catched: " + ex);
-
                 using (var stream = ex.Response.GetResponseStream())
                 using (var reader = new StreamReader(stream))
                 {

--- a/IotaCSharpApi/Api/Utils/Rest/JsonWebClient.cs
+++ b/IotaCSharpApi/Api/Utils/Rest/JsonWebClient.cs
@@ -73,8 +73,7 @@ namespace Iota.Lib.CSharp.Api.Utils.Rest
                     }
                     catch (System.Exception)
                     {
-                        // errorResponse is not a valid JSON
-                        deserialized = errorResponse;
+                        deserialized = "Caught WebException but was unable to deserialize content (no JSON).";
                     }
                     throw new IotaApiException(deserialized, ex);
                 }


### PR DESCRIPTION
Exceptions while deserializing response led to wrong exception. Fixed now.

Failing unit tests due to node incompatibilities.